### PR TITLE
Encode headers back from unicode to str on prepare

### DIFF
--- a/mailthon/headers.py
+++ b/mailthon/headers.py
@@ -74,7 +74,7 @@ class Headers(UnicodeDict):
             if key == 'Bcc' or key == 'Resent-Bcc':
                 continue
             del mime[key]
-            mime[key] = self[key]
+            mime[key] = self[key].encode('utf-8')
 
 
 def subject(text):


### PR DESCRIPTION
Headers should be encoded back to str, before generating string from mime object.
Before fix:

``` python
In [51]: a
Out[51]: <mailthon.enclosure.Attachment at 0x10efdc790>

In [52]: a.headers
Out[52]: {'Content-Disposition': u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"'}

In [53]: a.mime().items()
Out[53]:
[('Content-Type', 'application/rtf'),
 ('MIME-Version', '1.0'),
 ('Content-Transfer-Encoding', 'base64'),
 ('Content-Disposition',
  u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"')]

In [54]: a.mime().items().as_string()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/Users/psih/Work/nimble-server/<ipython-input-54-316d63cbe522> in <module>()
----> 1 a.mime().items().as_string()

AttributeError: 'list' object has no attribute 'as_string'

In [55]: a.mime().as_string()
Out[55]: 'Content-Type: application/rtf\nMIME-Version: 1.0\nContent-Transfer-Encoding: base64\nContent-Disposition: =?utf-8?b?YXR0YWNobWVudDsgZmlsZW5hbWU9ItC60LDQvdCw0LQ=?=\n =?utf-8?b?0LBf0YjQvNC+0YIucnRmIg==?=\n\ne1xydGYxXGFuc2lcYW5zaWNwZzEyNTFcY29jb2FydGYxMzQ4XGNvY29hc3VicnRmMTcwCntcZm9u\ndHRibFxmMFxmc3dpc3NcZmNoYXJzZXQwIEhlbHZldGljYTt9CntcY29sb3J0Ymw7XHJlZDI1NVxn\ncmVlbjI1NVxibHVlMjU1O30KXHBhcGVydzExOTAwXHBhcGVyaDE2ODQwXG1hcmdsMTQ0MFxtYXJn\ncjE0NDBcdmlld3cxNTAyMFx2aWV3aDEwMTIwXHZpZXdraW5kMApccGFyZFx0eDU2Nlx0eDExMzNc\ndHgxNzAwXHR4MjI2N1x0eDI4MzRcdHgzNDAxXHR4Mzk2OFx0eDQ1MzVcdHg1MTAyXHR4NTY2OVx0\neDYyMzZcdHg2ODAzXHBhcmRpcm5hdHVyYWwKClxmMFxmczI0IFxjZjAgMS4gXHVjMFx1MTA1NSBc\ndTEwNzIgXHUxMDg5IFx1MTA4NyBcdTEwODYgXHUxMDg4IFx1MTA5MCBcCjIuIDFcdWMwXHUxMDgy\nICBcdTEwNzYgXHUxMDg2IFx1MTA4MyBcdTEwODMgXHUxMDcyIFx1MTA4OCBcdTEwODYgXHUxMDc0\nIFwKMy4gXHVjMFx1MTA0NCBcdTEwODYgXHUxMDgyIFx1MTA4MCAtXHUxMDczIFx1MTA4MCBcdTEw\nODMgXHUxMDc3IFx1MTA5MCBcdTEwOTkgXAo0LiBcdWMwXHUxMDUwIFx1MTA4NiBcdTEwODUgXHUx\nMDkyIFx1MTA3NyBcdTEwOTAgXHUxMDk5ICBcdTEwODggXHUxMDg2IFx1MTA5NiBcdTEwNzcgXHUx\nMDg1ICAoMiBcdTEwOTYgXHUxMDkwICkgK1wKNS4gXHVjMFx1MTA2NCBcdTEwODYgXHUxMDg4IFx1\nMTA5MCBcdTEwOTkgIFx1MTA4OSBcdTEwODAgXHUxMDg1IFx1MTA4MCBcdTEwNzcgIFx1MTA3NCAg\nXHUxMDgyIFx1MTA4MyBcdTEwNzcgXHUxMDkwIFx1MTA4MiBcdTEwOTEgICtcCjYuIFx1YzBcdTEw\nNTUgXHUxMDgzIFx1MTA3MiBcdTEwNzQgXHUxMDgyIFx1MTA4MCAgXAo3LiBcdWMwXHUxMDYwIFx1\nMTA5MSBcdTEwOTAgXHUxMDczIFx1MTA4NiBcdTEwODMgXHUxMDgyIFx1MTA4MCAgLSBcJzg1IFx1\nMTA5NiBcdTEwOTAgXHUxMDkxIFx1MTA4MiBcdTEwODAgIChQeUNvbiwgSXJvbiBNYWlkZW4sIFx1\nMTA1NSBcdTEwODggXHUxMDg2IFx1MTA4OSBcdTEwOTAgXHUxMDg2ICBcdTEwODkgXHUxMDc3IFx1\nMTA4OCBcdTEwNzIgXHUxMTAzICwpICtcCjguIFx1YzBcdTEwNDEgXHUxMDg4IFx1MTA4MCBcdTEw\nNzYgXHUxMDc4IFx1MTA4MCAgKFx1MTA4NSBcdTEwNzIgIFx1MTA4OSBcdTEwNzcgXHUxMDczIFx1\nMTA3NyApICtcCjkuIFx1YzBcdTEwNDQgXHUxMDc4IFx1MTA4MCBcdTEwODUgXHUxMDg5IFx1MTA5\nOSAgK1wKMTAuIFx1YzBcdTEwNTAgXHUxMDg4IFx1MTA4NiBcdTEwODkgXHUxMDg5IFx1MTA4NiBc\ndTEwNzQgXHUxMDgyIFx1MTA4MCAgXHUxMDczIFx1MTA3NyBcdTEwNzUgXHUxMDg2IFx1MTA3NCBc\ndTEwOTkgXHUxMDc3ICAoXHUxMDg1IFx1MTA3MiAgXHUxMDg5IFx1MTA3NyBcdTEwNzMgXHUxMDc3\nICkgXAoxMi4gNCBcdWMwXHUxMDg3IFx1MTA3MiBcdTEwODggXHUxMDk5ICBcdTEwOTAgXHUxMDg4\nIFx1MTA5MSBcdTEwODkgXHUxMDg2IFx1MTA3NCAgK1wKMTMuIFx1YzBcdTEwNTMgXHUxMDg2IFx1\nMTA4OSBcdTEwODIgXHUxMDgwICAtIFx1MTA5MyBcdTEwNzkgIFx1MTA4NyBcdTEwNzIgXHUxMDg4\nICArXAoxNC4gXHVjMFx1MTA1MyBcdTEwNzIgXHUxMDkxIFx1MTA5NiBcdTEwODUgXHUxMDgwIFx1\nMTA4MiBcdTEwODAgICtcCjE1LiBcdWMwXHUxMDUzIFx1MTA4NiBcdTEwOTEgXHUxMDkwIFx1MTA5\nMSAgKyBcdTEwNzkgXHUxMDcyIFx1MTA4OCBcdTExMDMgXHUxMDc2IFx1MTA4MiBcdTEwNzIgIChc\ndTEwODkgIFx1MTA4NyBcdTEwODggXHUxMDcyIFx1MTA3NCBcdTEwODAgXHUxMDgzIFx1MTEwMCBc\ndTEwODUgXHUxMDg2IFx1MTA4MSAgXHUxMDc0IFx1MTA4MCBcdTEwODMgXHUxMDgyIFx1MTA4NiBc\ndTEwODEgKVwKMTYuIFx1YzBcdTEwNTUgXHUxMDc3IFx1MTA4OCBcdTEwNzcgXHUxMDkzIFx1MTA4\nNiBcdTEwNzYgXHUxMDg1IFx1MTA4MCBcdTEwODIgIFx1MTA4NSBcdTEwNzIgIFx1MTA4OCBcdTEw\nODYgXHUxMDc5IFx1MTA3NyBcdTEwOTAgXHUxMDgyIFx1MTA5MSAgXHUxMDg2IFx1MTA5MCAgXHUx\nMDkwIFx1MTA3MiBcdTEwODEgXHUxMDg0IC1cdTEwODIgXHUxMDcyIFx1MTA4NyBcdTEwODkgXHUx\nMDkxIFx1MTA4MyBcdTEwOTkgXAoxNy4gXHVjMFx1MTA2MyBcdTEwODAgXHUxMDkwIFx1MTA3MiBc\ndTEwODMgXHUxMDgyIFx1MTA3MiBcCjE4LiBcdWMwXHUxMDUwIFx1MTA4NiBcdTEwODMgXHUxMDc3\nIFx1MTA4OSBcdTEwNzIgL1x1MTA4OSBcdTEwODcgXHUxMDg4IFx1MTA3NyBcdTEwODEgIFx1MTA4\nNyBcdTEwODggXHUxMDg2IFx1MTA5MCBcdTEwODAgXHUxMDc0ICBcdTEwNzIgXHUxMDgzIFx1MTA4\nMyBcdTEwNzcgXHUxMDg4IFx1MTA3NSBcdTEwODAgXHUxMDgwIFwKMTkuIFx1YzBcdTEwNDAgXHUx\nMDgyIFx1MTA4MiBcdTEwOTEgXHUxMDg0ICwgXHUxMDcyIFx1MTA4NCBcdTEwNzcgXHUxMDg4IFx1\nMTA4MCBcdTEwODIgXHUxMDcyIFx1MTA4NSBcdTEwODkgXHUxMDgyIFx1MTA4MCBcdTEwNzcgIFx1\nMTA3NCBcdTEwODAgXHUxMDgzIFx1MTA4MiBcdTEwODAgXAoyMC4gXHVjMFx1MTA1MCBcdTEwNzcg\nXHUxMDg3IFx1MTA4MiBcdTEwNzIgICtcCjIxLiBcdWMwXHUxMDUyIFx1MTA3NyBcdTEwODggXHUx\nMDg4IFx1MTA3NyBcdTEwODMgIFx1MTA4MiBcdTEwODYgXHUxMDkyIFx1MTA5MCBcdTEwNzIgICtc\nCjIyLiBcdWMwXHUxMDQ0IFx1MTA4NiBcdTEwNzggXHUxMDc2IFx1MTA3NyBcdTEwNzQgXHUxMDgw\nIFx1MTA4MiAgK1wKMjMuIFx1YzBcdTEwNTcgXHUxMDc3IFx1MTA4NSBcdTEwNzYgXHUxMDcyIFx1\nMTA4MyBcdTEwODAgICtcCjI0LiBcdWMwXHUxMDU4IFx1MTA3NyBcdTEwODggXHUxMDg0IFx1MTA4\nMCBcdTEwODIgIFx1MTA3NCBcdTEwNzcgXHUxMDg4IFx1MTA5MyAtXHUxMDg1IFx1MTA4MCBcdTEw\nNzkgICtcCjI1LiBcdWMwXHUxMDk3IFx1MTA3NyBcdTEwOTAgXHUxMDgyIFx1MTA3MiAsIFx1MTA4\nNyBcdTEwNzIgXHUxMDg5IFx1MTA5MCBcdTEwNzIgLCBcdTEwNzIgXHUxMDg1IFx1MTA5MCBcdTEw\nODAgXHUxMDg3IFx1MTA4OCBcdTEwNzcgXHUxMDg5IFx1MTA4NyBcdTEwNzcgXHUxMDg4IFx1MTA3\nMiBcdTEwODUgXHUxMDkwICwgXHUxMDczIFx1MTA4OCBcdTEwODAgXHUxMDkwIFx1MTA3NCBcdTEw\nNzIgLCBcdTEwNzkgXHUxMDkxIFx1MTA3MyBcdTEwODUgXHUxMDcyIFx1MTEwMyAgXHUxMDg1IFx1\nMTA4MCBcdTEwOTAgXHUxMDgyIFx1MTA3MiBcClwKfQ=='
```

-- you can see that `Content-Disposition` header is broken (it had unicode value and was base64encoded into that mess)

After fix:

``` python
In [2]: a = Attachment(u"/Users/psih/Documents/канада_шмот.rtf")

In [3]: a.headers
Out[3]: {'Content-Disposition': u'attachment; filename="\u043a\u0430\u043d\u0430\u0434\u0430_\u0448\u043c\u043e\u0442.rtf"'}

In [4]: a.mime().items()
Out[4]:
[('Content-Type', 'application/rtf'),
 ('MIME-Version', '1.0'),
 ('Content-Transfer-Encoding', 'base64'),
 ('Content-Disposition',
  'attachment; filename="\xd0\xba\xd0\xb0\xd0\xbd\xd0\xb0\xd0\xb4\xd0\xb0_\xd1\x88\xd0\xbc\xd0\xbe\xd1\x82.rtf"')]

In [5]: a.mime().as_string()
Out[5]: 'Content-Type: application/rtf\nMIME-Version: 1.0\nContent-Transfer-Encoding: base64\nContent-Disposition: attachment; filename="\xd0\xba\xd0\xb0\xd0\xbd\xd0\xb0\xd0\xb4\xd0\xb0_\xd1\x88\xd0\xbc\xd0\xbe\xd1\x82.rtf"\n\ne1xydGYxXGFuc2lcYW5zaWNwZzEyNTFcY29jb2FydGYxMzQ4XGNvY29hc3VicnRmMTcwCntcZm9u\ndHRibFxmMFxmc3dpc3NcZmNoYXJzZXQwIEhlbHZldGljYTt9CntcY29sb3J0Ymw7XHJlZDI1NVxn\ncmVlbjI1NVxibHVlMjU1O30KXHBhcGVydzExOTAwXHBhcGVyaDE2ODQwXG1hcmdsMTQ0MFxtYXJn\ncjE0NDBcdmlld3cxNTAyMFx2aWV3aDEwMTIwXHZpZXdraW5kMApccGFyZFx0eDU2Nlx0eDExMzNc\ndHgxNzAwXHR4MjI2N1x0eDI4MzRcdHgzNDAxXHR4Mzk2OFx0eDQ1MzVcdHg1MTAyXHR4NTY2OVx0\neDYyMzZcdHg2ODAzXHBhcmRpcm5hdHVyYWwKClxmMFxmczI0IFxjZjAgMS4gXHVjMFx1MTA1NSBc\ndTEwNzIgXHUxMDg5IFx1MTA4NyBcdTEwODYgXHUxMDg4IFx1MTA5MCBcCjIuIDFcdWMwXHUxMDgy\nICBcdTEwNzYgXHUxMDg2IFx1MTA4MyBcdTEwODMgXHUxMDcyIFx1MTA4OCBcdTEwODYgXHUxMDc0\nIFwKMy4gXHVjMFx1MTA0NCBcdTEwODYgXHUxMDgyIFx1MTA4MCAtXHUxMDczIFx1MTA4MCBcdTEw\nODMgXHUxMDc3IFx1MTA5MCBcdTEwOTkgXAo0LiBcdWMwXHUxMDUwIFx1MTA4NiBcdTEwODUgXHUx\nMDkyIFx1MTA3NyBcdTEwOTAgXHUxMDk5ICBcdTEwODggXHUxMDg2IFx1MTA5NiBcdTEwNzcgXHUx\nMDg1ICAoMiBcdTEwOTYgXHUxMDkwICkgK1wKNS4gXHVjMFx1MTA2NCBcdTEwODYgXHUxMDg4IFx1\nMTA5MCBcdTEwOTkgIFx1MTA4OSBcdTEwODAgXHUxMDg1IFx1MTA4MCBcdTEwNzcgIFx1MTA3NCAg\nXHUxMDgyIFx1MTA4MyBcdTEwNzcgXHUxMDkwIFx1MTA4MiBcdTEwOTEgICtcCjYuIFx1YzBcdTEw\nNTUgXHUxMDgzIFx1MTA3MiBcdTEwNzQgXHUxMDgyIFx1MTA4MCAgXAo3LiBcdWMwXHUxMDYwIFx1\nMTA5MSBcdTEwOTAgXHUxMDczIFx1MTA4NiBcdTEwODMgXHUxMDgyIFx1MTA4MCAgLSBcJzg1IFx1\nMTA5NiBcdTEwOTAgXHUxMDkxIFx1MTA4MiBcdTEwODAgIChQeUNvbiwgSXJvbiBNYWlkZW4sIFx1\nMTA1NSBcdTEwODggXHUxMDg2IFx1MTA4OSBcdTEwOTAgXHUxMDg2ICBcdTEwODkgXHUxMDc3IFx1\nMTA4OCBcdTEwNzIgXHUxMTAzICwpICtcCjguIFx1YzBcdTEwNDEgXHUxMDg4IFx1MTA4MCBcdTEw\nNzYgXHUxMDc4IFx1MTA4MCAgKFx1MTA4NSBcdTEwNzIgIFx1MTA4OSBcdTEwNzcgXHUxMDczIFx1\nMTA3NyApICtcCjkuIFx1YzBcdTEwNDQgXHUxMDc4IFx1MTA4MCBcdTEwODUgXHUxMDg5IFx1MTA5\nOSAgK1wKMTAuIFx1YzBcdTEwNTAgXHUxMDg4IFx1MTA4NiBcdTEwODkgXHUxMDg5IFx1MTA4NiBc\ndTEwNzQgXHUxMDgyIFx1MTA4MCAgXHUxMDczIFx1MTA3NyBcdTEwNzUgXHUxMDg2IFx1MTA3NCBc\ndTEwOTkgXHUxMDc3ICAoXHUxMDg1IFx1MTA3MiAgXHUxMDg5IFx1MTA3NyBcdTEwNzMgXHUxMDc3\nICkgXAoxMi4gNCBcdWMwXHUxMDg3IFx1MTA3MiBcdTEwODggXHUxMDk5ICBcdTEwOTAgXHUxMDg4\nIFx1MTA5MSBcdTEwODkgXHUxMDg2IFx1MTA3NCAgK1wKMTMuIFx1YzBcdTEwNTMgXHUxMDg2IFx1\nMTA4OSBcdTEwODIgXHUxMDgwICAtIFx1MTA5MyBcdTEwNzkgIFx1MTA4NyBcdTEwNzIgXHUxMDg4\nICArXAoxNC4gXHVjMFx1MTA1MyBcdTEwNzIgXHUxMDkxIFx1MTA5NiBcdTEwODUgXHUxMDgwIFx1\nMTA4MiBcdTEwODAgICtcCjE1LiBcdWMwXHUxMDUzIFx1MTA4NiBcdTEwOTEgXHUxMDkwIFx1MTA5\nMSAgKyBcdTEwNzkgXHUxMDcyIFx1MTA4OCBcdTExMDMgXHUxMDc2IFx1MTA4MiBcdTEwNzIgIChc\ndTEwODkgIFx1MTA4NyBcdTEwODggXHUxMDcyIFx1MTA3NCBcdTEwODAgXHUxMDgzIFx1MTEwMCBc\ndTEwODUgXHUxMDg2IFx1MTA4MSAgXHUxMDc0IFx1MTA4MCBcdTEwODMgXHUxMDgyIFx1MTA4NiBc\ndTEwODEgKVwKMTYuIFx1YzBcdTEwNTUgXHUxMDc3IFx1MTA4OCBcdTEwNzcgXHUxMDkzIFx1MTA4\nNiBcdTEwNzYgXHUxMDg1IFx1MTA4MCBcdTEwODIgIFx1MTA4NSBcdTEwNzIgIFx1MTA4OCBcdTEw\nODYgXHUxMDc5IFx1MTA3NyBcdTEwOTAgXHUxMDgyIFx1MTA5MSAgXHUxMDg2IFx1MTA5MCAgXHUx\nMDkwIFx1MTA3MiBcdTEwODEgXHUxMDg0IC1cdTEwODIgXHUxMDcyIFx1MTA4NyBcdTEwODkgXHUx\nMDkxIFx1MTA4MyBcdTEwOTkgXAoxNy4gXHVjMFx1MTA2MyBcdTEwODAgXHUxMDkwIFx1MTA3MiBc\ndTEwODMgXHUxMDgyIFx1MTA3MiBcCjE4LiBcdWMwXHUxMDUwIFx1MTA4NiBcdTEwODMgXHUxMDc3\nIFx1MTA4OSBcdTEwNzIgL1x1MTA4OSBcdTEwODcgXHUxMDg4IFx1MTA3NyBcdTEwODEgIFx1MTA4\nNyBcdTEwODggXHUxMDg2IFx1MTA5MCBcdTEwODAgXHUxMDc0ICBcdTEwNzIgXHUxMDgzIFx1MTA4\nMyBcdTEwNzcgXHUxMDg4IFx1MTA3NSBcdTEwODAgXHUxMDgwIFwKMTkuIFx1YzBcdTEwNDAgXHUx\nMDgyIFx1MTA4MiBcdTEwOTEgXHUxMDg0ICwgXHUxMDcyIFx1MTA4NCBcdTEwNzcgXHUxMDg4IFx1\nMTA4MCBcdTEwODIgXHUxMDcyIFx1MTA4NSBcdTEwODkgXHUxMDgyIFx1MTA4MCBcdTEwNzcgIFx1\nMTA3NCBcdTEwODAgXHUxMDgzIFx1MTA4MiBcdTEwODAgXAoyMC4gXHVjMFx1MTA1MCBcdTEwNzcg\nXHUxMDg3IFx1MTA4MiBcdTEwNzIgICtcCjIxLiBcdWMwXHUxMDUyIFx1MTA3NyBcdTEwODggXHUx\nMDg4IFx1MTA3NyBcdTEwODMgIFx1MTA4MiBcdTEwODYgXHUxMDkyIFx1MTA5MCBcdTEwNzIgICtc\nCjIyLiBcdWMwXHUxMDQ0IFx1MTA4NiBcdTEwNzggXHUxMDc2IFx1MTA3NyBcdTEwNzQgXHUxMDgw\nIFx1MTA4MiAgK1wKMjMuIFx1YzBcdTEwNTcgXHUxMDc3IFx1MTA4NSBcdTEwNzYgXHUxMDcyIFx1\nMTA4MyBcdTEwODAgICtcCjI0LiBcdWMwXHUxMDU4IFx1MTA3NyBcdTEwODggXHUxMDg0IFx1MTA4\nMCBcdTEwODIgIFx1MTA3NCBcdTEwNzcgXHUxMDg4IFx1MTA5MyAtXHUxMDg1IFx1MTA4MCBcdTEw\nNzkgICtcCjI1LiBcdWMwXHUxMDk3IFx1MTA3NyBcdTEwOTAgXHUxMDgyIFx1MTA3MiAsIFx1MTA4\nNyBcdTEwNzIgXHUxMDg5IFx1MTA5MCBcdTEwNzIgLCBcdTEwNzIgXHUxMDg1IFx1MTA5MCBcdTEw\nODAgXHUxMDg3IFx1MTA4OCBcdTEwNzcgXHUxMDg5IFx1MTA4NyBcdTEwNzcgXHUxMDg4IFx1MTA3\nMiBcdTEwODUgXHUxMDkwICwgXHUxMDczIFx1MTA4OCBcdTEwODAgXHUxMDkwIFx1MTA3NCBcdTEw\nNzIgLCBcdTEwNzkgXHUxMDkxIFx1MTA3MyBcdTEwODUgXHUxMDcyIFx1MTEwMyAgXHUxMDg1IFx1\nMTA4MCBcdTEwOTAgXHUxMDgyIFx1MTA3MiBcClwKfQ=='
```
